### PR TITLE
Fixes incorrect prompt arrow color

### DIFF
--- a/themes/awesomepanda.zsh-theme
+++ b/themes/awesomepanda.zsh-theme
@@ -1,13 +1,11 @@
 # the svn plugin has to be activated for this to work.
-
-PROMPT='%{$fg_bold[red]%}➜ %{$fg_bold[green]%}%p %{$fg[cyan]%}%c %{$fg_bold[blue]%}$(git_prompt_info)%{$fg_bold[blue]%}$(svn_prompt_info)%{$reset_color%}'
+local ret_status="%(?:%{$fg_bold[green]%}➜ :%{$fg_bold[red]%}➜ %s)"
+PROMPT='${ret_status}%{$fg_bold[green]%}%p %{$fg[cyan]%}%c %{$fg_bold[blue]%}$(git_prompt_info)%{$fg_bold[blue]%}$(svn_prompt_info)%{$reset_color%}'
 
 ZSH_THEME_GIT_PROMPT_PREFIX="git:(%{$fg[red]%}"
 ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%}"
 ZSH_THEME_GIT_PROMPT_DIRTY="%{$fg[blue]%})%{$fg[yellow]%} ✗ %{$reset_color%}"
 ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg[blue]%}) "
-
-
 
 ZSH_PROMPT_BASE_COLOR="%{$fg_bold[blue]%}"
 ZSH_THEME_REPO_NAME_COLOR="%{$fg_bold[red]%}"


### PR DESCRIPTION
Fixes a bug where color of status arrow in prompt is red even when the exit code was zero (or success). This fix correclty returns green arrow on success and red for non-success exit code.
